### PR TITLE
Update TagHelper to support script type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 These are the changes to each version that has been released
 on the official Visual Studio extension gallery
 
+## 5.0
+
+- [x] Renamed to `BundlerMinifierPlus` to maintain the nuget package.
+- [x] Added support to .net 5.0
+
 ## 2.4
 
 - [x] .csproj based ASP.NET Core apps support bundle-on-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 These are the changes to each version that has been released
 on the official Visual Studio extension gallery
 
+## 5.2
+
+- [x] NUglify got updated to 1.20.2
+
 ## 5.1
 
 - [x] NUglify got updated to 1.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
-# Roadmap
-
-- [ ] ASP.NET Core TagHelper support
-- [ ] Create additional source map for the bundle files
-- [ ] Adopt new VS Error List API
 
 # Changelog
 
 These are the changes to each version that has been released
 on the official Visual Studio extension gallery
+
+## 5.1
+
+- [x] NUglify got updated to 1.20.0
+- [x] Added support for .net 6.0
 
 ## 5.0
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ minification of JS, CSS and HTML files.
 
 Package name is now `BuildBundlerMinifierPlus`, build the projects then use local Nuget repository to get access to it. Here is list of paackages:
 
-* BuildBundlerMinifierPlus
-* BundlerMinifierPlus.Core
-* BundlerMinifierPlus.TagHelpers
+* `BuildBundlerMinifierPlus` version 5.0
+* `BundlerMinifierPlus.Core` version 5.0
+* `BundlerMinifierPlus.TagHelpers` version 5.0
 
 
 Download the extension (for [this repo](https://github.com/failwyn/BundlerMinifier)) at the

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ minification of JS, CSS and HTML files.
 
 Package name is now `BuildBundlerMinifierPlus`, build the projects then use local Nuget repository to get access to it. Here is list of paackages:
 
-* `[BuildBundlerMinifierPlus](https://www.nuget.org/packages/BuildBundlerMinifierPlus/)` version 5.0
-* `[BundlerMinifierPlus.Core](https://www.nuget.org/packages/BundlerMinifierPlus.Core/)` version 5.0
-* `[BundlerMinifierPlus.TagHelpers](https://www.nuget.org/packages/BundlerMinifierPlus.TagHelpers/)` version 5.0
+* [BuildBundlerMinifierPlus](https://www.nuget.org/packages/BuildBundlerMinifierPlus/) version 5.0
+* [BundlerMinifierPlus.Core](https://www.nuget.org/packages/BundlerMinifierPlus.Core/) version 5.0
+* [BundlerMinifierPlus.TagHelpers](https://www.nuget.org/packages/BundlerMinifierPlus.TagHelpers/) version 5.0
 
 
 Download the extension (for [this repo](https://github.com/failwyn/BundlerMinifier)) at the

--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@
 A Visual Studio extension that let's you configure bundling and
 minification of JS, CSS and HTML files.
 
-Download the extension at the
+Package name is now `BuildBundlerMinifierPlus`, build the projects then use local Nuget repository to get access to it. Here is list of paackages:
+
+* BuildBundlerMinifierPlus
+* BundlerMinifierPlus.Core
+* BundlerMinifierPlus.TagHelpers
+
+
+Download the extension (for [this repo](https://github.com/failwyn/BundlerMinifier)) at the
 [VS Gallery](https://visualstudiogallery.msdn.microsoft.com/9ec27da7-e24b-4d56-8064-fd7e88ac1c40)
 
 ---------------------------------------

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ minification of JS, CSS and HTML files.
 
 Package name is now `BuildBundlerMinifierPlus`, build the projects then use local Nuget repository to get access to it. Here is list of paackages:
 
-* `BuildBundlerMinifierPlus` version 5.0
-* `BundlerMinifierPlus.Core` version 5.0
-* `BundlerMinifierPlus.TagHelpers` version 5.0
+* `[BuildBundlerMinifierPlus](https://www.nuget.org/packages/BuildBundlerMinifierPlus/)` version 5.0
+* `[BundlerMinifierPlus.Core](https://www.nuget.org/packages/BundlerMinifierPlus.Core/)` version 5.0
+* `[BundlerMinifierPlus.TagHelpers](https://www.nuget.org/packages/BundlerMinifierPlus.TagHelpers/)` version 5.0
 
 
 Download the extension (for [this repo](https://github.com/failwyn/BundlerMinifier)) at the

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ minification of JS, CSS and HTML files.
 
 Package name is now `BuildBundlerMinifierPlus`, build the projects then use local Nuget repository to get access to it. Here is list of paackages:
 
-* [BuildBundlerMinifierPlus](https://www.nuget.org/packages/BuildBundlerMinifierPlus/) version 5.0
-* [BundlerMinifierPlus.Core](https://www.nuget.org/packages/BundlerMinifierPlus.Core/) version 5.0
-* [BundlerMinifierPlus.TagHelpers](https://www.nuget.org/packages/BundlerMinifierPlus.TagHelpers/) version 5.0
+* [BuildBundlerMinifierPlus](https://www.nuget.org/packages/BuildBundlerMinifierPlus/) version 5.2
+* [BundlerMinifierPlus.Core](https://www.nuget.org/packages/BundlerMinifierPlus.Core/) version 5.2
+* [BundlerMinifierPlus.TagHelpers](https://www.nuget.org/packages/BundlerMinifierPlus.TagHelpers/) version 5.2
 
 
 Download the extension (for [this repo](https://github.com/failwyn/BundlerMinifier)) at the

--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -3,16 +3,18 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <Version>1.0.0</Version>
-    <TargetFrameworks>netcoreapp1.0;net452;netcoreapp2.0;netstandard2.0;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);DOTNET</DefineConstants>
-    <AssemblyName>dotnet-bundle</AssemblyName>
+    <Authors>Mads Kristensen, salar2k</Authors>
     <OutputType>Exe</OutputType>
-    <PackageId>BundlerMinifier.Core</PackageId>
+    <PackageId>BundlerMinifierPlus.Core</PackageId>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <AssemblyVersion>5.0</AssemblyVersion>
+    <FileVersion>5.0</FileVersion>
+    <Version>5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);DOTNET</DefineConstants>
     <Authors>Mads Kristensen, salar2k</Authors>
     <OutputType>Exe</OutputType>
@@ -13,9 +13,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>5.0</AssemblyVersion>
-    <FileVersion>5.0</FileVersion>
-    <Version>5.0</Version>
+    <AssemblyVersion>5.1</AssemblyVersion>
+    <FileVersion>5.1</FileVersion>
+    <Version>5.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUglify" Version="1.17.10" />
+    <PackageReference Include="NUglify" Version="1.20.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -8,6 +8,7 @@
     <Authors>Mads Kristensen, salar2k</Authors>
     <OutputType>Exe</OutputType>
     <PackageId>BundlerMinifierPlus.Core</PackageId>
+    <RepositoryUrl>https://github.com/salarcode/BundlerMinifierPlus</RepositoryUrl>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -13,9 +13,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>5.1</AssemblyVersion>
-    <FileVersion>5.1</FileVersion>
-    <Version>5.1</Version>
+    <AssemblyVersion>5.2</AssemblyVersion>
+    <FileVersion>5.2</FileVersion>
+    <Version>5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUglify" Version="1.20.0" />
+    <PackageReference Include="NUglify" Version="1.20.2" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/BundlerMinifier.TagHelpers/BundleTagHelper.cs
+++ b/src/BundlerMinifier.TagHelpers/BundleTagHelper.cs
@@ -54,6 +54,9 @@ namespace BundlerMinifier.TagHelpers
         [HtmlAttributeName("name")]
         public string BundleName { get; set; }
 
+        [HtmlAttributeName("type")]
+        public string ScriptType {get; set;} = "text/javascript";
+
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
             output.SuppressOutput();
@@ -74,7 +77,7 @@ namespace BundlerMinifier.TagHelpers
 
                     if (bundle.OutputFileUrl.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
                     {
-                        output.Content.AppendHtmlLine($"<script src=\"{_htmlEncoder.Encode(src)}\" type=\"text/javascript\"></script>");
+                        output.Content.AppendHtmlLine($"<script src=\"{_htmlEncoder.Encode(src)}\" type=\"{ScriptType}\"></script>");
                     }
                     else if (bundle.OutputFileUrl.EndsWith(".css", StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
+++ b/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
@@ -5,10 +5,10 @@
     
     <Authors>Gérald Barré, Mads Kristensen, RockstarDev, salar2k</Authors>
     <Product>Bundler &amp; Minifier TagHelpers</Product>
-    <PackageLicenseUrl>https://github.com/madskristensen/BundlerMinifier/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/salarcode/BundlerMinifierPlus/blob/master/LICENSE</PackageLicenseUrl>
     <Copyright>Copyright 2022</Copyright>
     <PackageIconUrl>https://raw.githubusercontent.com/madskristensen/BundlerMinifier/master/src/BundlerMinifierVsix/Resources/icon.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/madskristensen/BundlerMinifier</RepositoryUrl>
+    <RepositoryUrl>https://github.com/salarcode/BundlerMinifierPlus</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>concat;bundle;minify;minification;css;js;html;aspnet;netcore</PackageTags>
     <!-- forces SDK to copy dependencies into build output to make packing easier -->

--- a/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
+++ b/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
@@ -16,9 +16,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>5.1</AssemblyVersion>
-    <FileVersion>5.1</FileVersion>
-    <Version>5.1</Version>
+    <AssemblyVersion>5.2</AssemblyVersion>
+    <FileVersion>5.2</FileVersion>
+    <Version>5.2</Version>
     <PackageId>BundlerMinifierPlus.TagHelpers</PackageId>
   </PropertyGroup>
 

--- a/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
+++ b/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     
     <Authors>Gérald Barré, Mads Kristensen, RockstarDev, salar2k</Authors>
     <Product>Bundler &amp; Minifier TagHelpers</Product>
@@ -16,9 +16,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>5.0</AssemblyVersion>
-    <FileVersion>5.0</FileVersion>
-    <Version>5.0</Version>
+    <AssemblyVersion>5.1</AssemblyVersion>
+    <FileVersion>5.1</FileVersion>
+    <Version>5.1</Version>
     <PackageId>BundlerMinifierPlus.TagHelpers</PackageId>
   </PropertyGroup>
 

--- a/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
+++ b/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     
-    <Authors>Gérald Barré, Mads Kristensen, RockstarDev</Authors>
+    <Authors>Gérald Barré, Mads Kristensen, RockstarDev, salar2k</Authors>
     <Product>Bundler &amp; Minifier TagHelpers</Product>
     <PackageLicenseUrl>https://github.com/madskristensen/BundlerMinifier/blob/master/LICENSE</PackageLicenseUrl>
-    <Copyright>Copyright © 2018</Copyright>
+    <Copyright>Copyright 2022</Copyright>
     <PackageIconUrl>https://raw.githubusercontent.com/madskristensen/BundlerMinifier/master/src/BundlerMinifierVsix/Resources/icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/madskristensen/BundlerMinifier</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -16,6 +16,10 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <AssemblyVersion>5.0</AssemblyVersion>
+    <FileVersion>5.0</FileVersion>
+    <Version>5.0</Version>
+    <PackageId>BundlerMinifierPlus.TagHelpers</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -3,9 +3,9 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.3;netcoreapp2.0;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Title>Bundler &amp; Minifier</Title>
-    <PackageId>BuildBundlerMinifier</PackageId>
+    <PackageId>BuildBundlerMinifierPlus</PackageId>
 
     <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -19,6 +19,11 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <Authors>Mads Kristensen, salar2k</Authors>
+    <Copyright>Copyright 2022</Copyright>
+    <AssemblyVersion>5.0</AssemblyVersion>
+    <FileVersion>5.0</FileVersion>
+    <Version>5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,8 +32,8 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.1.0-*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" PrivateAssets="All" />
     <PackageReference Include="NUglify" Version="1.17.10" PrivateAssets="All" />
   </ItemGroup>

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Title>Bundler &amp; Minifier</Title>
     <PackageId>BuildBundlerMinifierPlus</PackageId>
 
@@ -21,9 +21,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Authors>Mads Kristensen, salar2k</Authors>
     <Copyright>Copyright 2022</Copyright>
-    <AssemblyVersion>5.0</AssemblyVersion>
-    <FileVersion>5.0</FileVersion>
-    <Version>5.0</Version>
+    <AssemblyVersion>5.1</AssemblyVersion>
+    <FileVersion>5.1</FileVersion>
+    <Version>5.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" PrivateAssets="All" />
-    <PackageReference Include="NUglify" Version="1.17.10" PrivateAssets="All" />
+    <PackageReference Include="NUglify" Version="1.20.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -14,7 +14,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageIconUrl>https://raw.githubusercontent.com/madskristensen/BundlerMinifier/master/src/BundlerMinifierVsix/Resources/icon.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/madskristensen/BundlerMinifier/blob/master/LICENSE</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/failwyn/BundlerMinifier</RepositoryUrl>
+    <RepositoryUrl>https://github.com/salarcode/BundlerMinifierPlus</RepositoryUrl>
     <PackageTags>concat;bundle;minify;minification;css;js;html</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -13,7 +13,7 @@
     <!-- forces SDK to copy dependencies into build output to make packing easier -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageIconUrl>https://raw.githubusercontent.com/madskristensen/BundlerMinifier/master/src/BundlerMinifierVsix/Resources/icon.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/madskristensen/BundlerMinifier/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/salarcode/BundlerMinifierPlus/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/salarcode/BundlerMinifierPlus</RepositoryUrl>
     <PackageTags>concat;bundle;minify;minification;css;js;html</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -21,9 +21,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Authors>Mads Kristensen, salar2k</Authors>
     <Copyright>Copyright 2022</Copyright>
-    <AssemblyVersion>5.1</AssemblyVersion>
-    <FileVersion>5.1</FileVersion>
-    <Version>5.1</Version>
+    <AssemblyVersion>5.2</AssemblyVersion>
+    <FileVersion>5.2</FileVersion>
+    <Version>5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" PrivateAssets="All" />
-    <PackageReference Include="NUglify" Version="1.20.0" PrivateAssets="All" />
+    <PackageReference Include="NUglify" Version="1.20.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/src/BundlerMinifier/build/BuildBundlerMinifierPlus.targets
+++ b/src/BundlerMinifier/build/BuildBundlerMinifierPlus.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_BundlerMinifierTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\net5.0\BundlerMinifier.dll</_BundlerMinifierTaskAssembly>
+    <_BundlerMinifierTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\net6.0\BundlerMinifier.dll</_BundlerMinifierTaskAssembly>
     <_BundlerMinifierTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">..\tools\net46\BundlerMinifier.dll</_BundlerMinifierTaskAssembly>
   </PropertyGroup>
 

--- a/src/BundlerMinifier/build/BuildBundlerMinifierPlus.targets
+++ b/src/BundlerMinifier/build/BuildBundlerMinifierPlus.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_BundlerMinifierTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\netstandard1.3\BundlerMinifier.dll</_BundlerMinifierTaskAssembly>
+    <_BundlerMinifierTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\net5.0\BundlerMinifier.dll</_BundlerMinifierTaskAssembly>
     <_BundlerMinifierTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">..\tools\net46\BundlerMinifier.dll</_BundlerMinifierTaskAssembly>
   </PropertyGroup>
 

--- a/src/BundlerMinifierTest/BundlerMinifierTest.csproj
+++ b/src/BundlerMinifierTest/BundlerMinifierTest.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.12" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BundlerMinifierTest/BundlerMinifierTest.csproj
+++ b/src/BundlerMinifierTest/BundlerMinifierTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>net46</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/BundlerMinifierTest/BundlerTest.cs
+++ b/src/BundlerMinifierTest/BundlerTest.cs
@@ -109,7 +109,7 @@ namespace BundlerMinifierTest
 
             // CSS
             string cssResult = File.ReadAllText(new FileInfo("../../../artifacts/foo.min.css").FullName);
-            Assert.AreEqual("body{background:url('/test.png')}body{display:block}body{background:url(test2/image.png?foo=hat)}", cssResult);
+            Assert.AreEqual("body{background:url('/test.png')}body{display:block}:root{--bb-width-test:}body{background:url(test2/image.png?foo=hat)}", cssResult);
 
             // HTML
             string htmlResult = File.ReadAllText("../../../artifacts/foo.min.html");

--- a/src/BundlerMinifierTest/artifacts/file2.css
+++ b/src/BundlerMinifierTest/artifacts/file2.css
@@ -1,1 +1,4 @@
 ﻿body {display: block}
+:root{
+    --bb-width-test: ;
+} 

--- a/src/BundlerMinifierVsix/BundlerMinifierVsix.csproj
+++ b/src/BundlerMinifierVsix/BundlerMinifierVsix.csproj
@@ -199,24 +199,24 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.0.0-previews-3-31605-261</Version>
+      <Version>17.2.32505.173</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Utilities">
-      <Version>17.0.0-previews-3-31605-261</Version>
+      <Version>17.2.32505.113</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.4183-preview4</Version>
+      <Version>17.2.2195</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>9.0.1</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.VisualStudio">
-      <Version>3.5.0</Version>
+      <Version>17.2.1</Version>
     </PackageReference>
     <PackageReference Include="NUglify">
-      <Version>1.17.10</Version>
+      <Version>1.20.2</Version>
     </PackageReference>
   </ItemGroup>
   <!-- end workaround -->

--- a/src/BundlerMinifierVsix/source.extension.vsixmanifest
+++ b/src/BundlerMinifierVsix/source.extension.vsixmanifest
@@ -4,9 +4,9 @@
         <Identity Id="5783ce1f-b23d-4e84-87a4-6b2cbe9e0602" Version="2.9.3" Language="en-US" Publisher="Jason Moore" />
         <DisplayName>Bundler &amp; Minifier 2022+</DisplayName>
         <Description xml:space="preserve">Adds support for bundling and minifying JavaScript, CSS and HTML files in any project.</Description>
-        <MoreInfo>https://github.com/failwyn/BundlerMinifier</MoreInfo>
+        <MoreInfo>https://github.com/salarcode/BundlerMinifierPlus</MoreInfo>
         <License>Resources\LICENSE</License>
-        <ReleaseNotes>https://github.com/failwyn/BundlerMinifier/blob/master/CHANGELOG.md</ReleaseNotes>
+        <ReleaseNotes>https://github.com/salarcode/BundlerMinifierPlus/blob/master/CHANGELOG.md</ReleaseNotes>
         <Icon>Resources\icon.png</Icon>
         <PreviewImage>Resources\preview.png</PreviewImage>
         <Tags>bundle, bundling, minify, minification, js, css, html</Tags>


### PR DESCRIPTION
Allow users to place the type into the bundle and have it appended to the script. This allows import inside of a bundled js file.