### PR TITLE
Add .NET 6 & 8 targets and create dotnet tool availability.

### DIFF
--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <Title>Bundler &amp; Minifier</Title>
     <PackageId>BuildBundlerMinifier2022</PackageId>
 
@@ -24,6 +24,13 @@
     <Version>2.9.9</Version>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0'" >
+	  <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+	  <OutputType>Exe</OutputType>
+	  <PackAsTool>true</PackAsTool>
+	  <ToolCommandName>bundle</ToolCommandName>      
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
@@ -32,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="17.4.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.4.0" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" PrivateAssets="All" />
-    <PackageReference Include="NUglify" Version="1.21.9" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NUglify" Version="1.21.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update the project file to create .NET6/8 outputs that enable dotnet tool support.

From Powershell:
```
> dotnet tool install BuildBundlerMinifier2022
You can invoke the tool from this directory using the following commands: 'dotnet tool run bundle' or 'dotnet bundle'.
Tool 'buildbundlerminifier2022' (version '2.9.9') was successfully installed. Entry is added to the manifest file D:\Repos\xxx\.config\dotnet-tools.json.
> dotnet tool run bundle
[31m[1mA configuration file called bundleconfig.json could not be found [0m[39m[49m
[33m[1mUsage: BundlerMinifier [[args]] [configPath]
 Each arg in args can be one of the following:
     - The name of an output to process (outputFileName in the configuration file)
         If no outputs to process are specified, all 
     - [ -? | -h | --help | help]        - Shows this help message
         All other arguments are ignored when one of the help switches are included
     - clean                             - Deletes artifacts from previous runs
         All other arguments are ignored when "clean" is included
         Not compatible with "watch"
     - watch                             - Deletes artifacts from previous runs
         Watches files that would cause specified rules to run
         Not compatible with "clean"
     - --no-color                        - Doesn't colorize output
     - [ -? | -h | --help ] to show this help message
 The configPath parameter may be omitted if a bundleconfig.json file is in the working directory
     otherwise, this parameter must be the location of a file containing the definitions for how
     the bundling and minification should be performed.
[0m[39m[49m
```
