### PR TITLE
Update dependencies

### DIFF
--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUglify" Version="1.21.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NUglify" Version="1.21.17" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
+++ b/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
@@ -26,7 +26,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -39,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="17.4.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.4.0" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUglify" Version="1.21.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="NUglify" Version="1.21.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BundlerMinifierTest/BundlerMinifierTest.csproj
+++ b/src/BundlerMinifierTest/BundlerMinifierTest.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.11.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates several dependencies to their latest patch and minor versions within the same major line.
The main motivation is updating NUglify, which fixes multiple JavaScript and CSS minification issues.

**Changes:**
- NUglify -> `v1.21.17` ([changelog](https://github.com/trullock/NUglify/blob/master/changelog.md))
- Newtonsoft.Json -> `v13.0.4` ([changelog](https://github.com/JamesNK/Newtonsoft.Json/releases/tag/13.0.4))
- Microsoft.AspNetCore.Mvc.TagHelpers -> `v2.3.0`
- MSTest.TestAdapter and MSTest.TestFramework -> `v3.11.0` ([changelog](https://github.com/microsoft/testfx/blob/main/docs/Changelog.md#3.11.0))

No functional changes in BundlerMinifier itself.